### PR TITLE
Update Babel package name.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "VSCode_ES6",
     "version": "0.0.1",
     "devDependencies": {
-        "babel": "*",
+        "babel-cli": "*",
         "tsd": "*"
     },
     "main": "lib/app.js"


### PR DESCRIPTION
With Babel 6, Babel CLI package was renamed from babel to babel-cli and it's now required to enable plugins.
